### PR TITLE
Add offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@
 
 <div align="center">
 
-| 🎨 **Theme System** | ✅ **Todo Management** | 🔔 **Smart Notifications** | 💾 **Persistent Storage** | 📊 **Progress Tracking** | 🔍 **Filtering/Sorting** | 🏷️ **Tags** | ♻️ **Recurring Tasks** | 👤 **Account Sync** |
-|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| Automatic dark/light mode switching with manual override | Add, edit, complete and delete todos with due dates | Browser notifications for due tasks | LocalStorage per user account | Percentage bar of completed tasks | Filter by status and sort by date | Organize todos with optional tags | Daily, weekly or monthly recurrence | Optional sign in to sync tasks locally |
+| 🎨 **Theme System** | ✅ **Todo Management** | 🔔 **Smart Notifications** | 💾 **Persistent Storage** | 📊 **Progress Tracking** | 🔍 **Filtering/Sorting** | 🏷️ **Tags** | ♻️ **Recurring Tasks** | 👤 **Account Sync** | 📴 **Offline Mode** |
+|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Automatic dark/light mode switching with manual override | Add, edit, complete and delete todos with due dates | Browser notifications for due tasks | LocalStorage per user account | Percentage bar of completed tasks | Filter by status and sort by date | Organize todos with optional tags | Daily, weekly or monthly recurrence | Optional sign in to sync tasks locally | Use the app even when offline |
 
 </div>
+
+This release introduces a basic service worker to cache the application shell so your tasks remain accessible without a network connection.
 
 ---
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,13 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('todo-app-cache-v1').then(cache =>
+      cache.addAll(['/', '/index.html'])
+    )
+  )
+})
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  )
+})

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,8 @@ function App() {
     return 'system'
   })
 
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
+  const [isOnline, setIsOnline] = useState(navigator.onLine)
 
   useEffect(() => {
     const handleMouseMove = (event) => {
@@ -23,6 +24,17 @@ function App() {
       window.removeEventListener('mousemove', handleMouseMove);
     };
   }, []);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
@@ -67,13 +79,18 @@ function App() {
   }
 
   return (
-    <div 
-      className="app" 
-      style={{ 
-        '--mouse-x': `${mousePosition.x}px`, 
-        '--mouse-y': `${mousePosition.y}px` 
+    <div
+      className="app"
+      style={{
+        '--mouse-x': `${mousePosition.x}px`,
+        '--mouse-y': `${mousePosition.y}px`
       }}
     >
+      {!isOnline && (
+        <div className="offline-banner">
+          Offline - changes will sync when connection is restored
+        </div>
+      )}
       <button
         onClick={() => setTheme(getNextTheme())}
         className="theme-toggle"

--- a/src/index.css
+++ b/src/index.css
@@ -1048,3 +1048,15 @@ select {
   }
 }
 
+.offline-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: var(--warning-color);
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  text-align: center;
+  z-index: 1000;
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,3 +8,13 @@ createRoot(document.getElementById('root')).render(
     <App />
   </StrictMode>,
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/service-worker.js')
+      .catch((err) => {
+        console.error('Service worker registration failed', err)
+      })
+  })
+}


### PR DESCRIPTION
## Summary
- add a simple service worker and register it
- show an offline banner when the user is not connected
- add offline styles
- document offline mode

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68837986e7788322bdd101f9b40b80c8